### PR TITLE
Allow custom headers

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -31,6 +31,7 @@ function Strategy(options, verify) {
   // TODO: What's the recommended field name for OpenID Connect?
   this._identifierField = options.identifierField || 'openid_identifier';
   this._scope = options.scope;
+  this._customHeaders = options.customHeaders;
   this._scopeSeparator = options.scopeSeparator || ' ';
   this._passReqToCallback = options.passReqToCallback;
   this._skipUserProfile = (options.skipUserProfile === undefined) ? false : options.skipUserProfile;
@@ -84,7 +85,7 @@ Strategy.prototype.authenticate = function(req, options) {
       if (err) { return self.error(err); }
     
       var oauth2 = new OAuth2(config.clientID,  config.clientSecret,
-                              '', config.authorizationURL, config.tokenURL);
+                              '', config.authorizationURL, config.tokenURL, self._customHeaders);
                               
       var callbackURL = options.callbackURL || config.callbackURL;
       if (callbackURL) {


### PR DESCRIPTION
The underlying OAuth lib allows custom headers, make this lib optionally allow custom headers.

Useful for [this usecase](https://github.com/ciaranj/node-oauth/pull/126).

BTW, thanks for forking this lib and publishing to NPM :+1: 
